### PR TITLE
Update username regex

### DIFF
--- a/lib/character.ex
+++ b/lib/character.ex
@@ -17,7 +17,7 @@ defmodule CommonsPub.Characters.Character do
   @defaults [
     cast:     [:username],
     required: [:username],
-    username: [ format: ~r(^[a-z][a-z0-9_]{2,30}$)i ],
+    username: [ format: ~r(^[a-z][a-z0-9_@.]{2,30}$)i ],
   ]
 
   def changeset(char \\ %Character{}, attrs, opts \\ []) do


### PR DESCRIPTION
We need to allow '@' and '.' so we can store full usernames of remote users with their hostname appended.